### PR TITLE
Add dry-run option

### DIFF
--- a/bin/vup.cr
+++ b/bin/vup.cr
@@ -4,6 +4,7 @@ require "option_parser"
 begin
   version = Vup::SemanticVersions::PATCH
   show = false
+  dry_run = false
   OptionParser.parse! do |parser|
     parser.banner = "Usage: vup"
     parser.on("-v", "--version", "Show version") { puts Vup::VERSION; exit 0 }
@@ -17,13 +18,14 @@ begin
       version = Vup::SemanticVersions::PATCH
     }
     parser.on("--show", "show current version") { show = true }
+    parser.on("-n", "--dry-run", "show version and files to change without actual change") { dry_run = true }
     parser.on("-h", "--help", "Show this help") { puts parser; exit 0 }
   end
 
   if show
     Vup::Show.new.run
   else
-    Vup::Up.new(version).bumpup_files
+    Vup::Up.new(version).run(dry_run)
   end
   exit 0
 rescue e

--- a/spec/vup/up_spec.cr
+++ b/spec/vup/up_spec.cr
@@ -131,8 +131,7 @@ describe Vup::Up do
           vup = k[:input].nil? ? Vup::Up.new : Vup::Up.new(k[:input])
           vup.load_version_cr
           vup.load_shard_yml
-          actual = vup.bumpup_version
-          actual.version.should eq(k[:expected])
+          vup.new_version.version.should eq(k[:expected])
         end
       end
     end


### PR DESCRIPTION
ref #6 
- add dry-run option
  - it shows not only next version but which files to change
  - this behavior does not match written in #6, but it is better, I think
- extact method and memoize version_cr_path
- change Vup::Up's interface
  - bumpup -> run
  - same as Vup::Show
