### PR TITLE
Change options. -M as major, -m as minor

### DIFF
--- a/bin/vup.cr
+++ b/bin/vup.cr
@@ -9,8 +9,8 @@ begin
   OptionParser.parse! do |parser|
     parser.banner = "Usage: vup"
     parser.on("-v", "--version", "Show version") { puts Vup::VERSION; exit 0 }
-    parser.on("-ma", "--major", "major version up") { version = Vup::SemanticVersions::MAJOR }
-    parser.on("-mi", "--minor", "minor version up") { version = Vup::SemanticVersions::MINOR }
+    parser.on("-M", "--major", "major version up") { version = Vup::SemanticVersions::MAJOR }
+    parser.on("-m", "--minor", "minor version up") { version = Vup::SemanticVersions::MINOR }
     parser.on("-p", "--patch", "patch version up") { version = Vup::SemanticVersions::PATCH }
     parser.on("--show", "show current version") { show = true }
     parser.on("-d", "--detail", "show update files") { detail = true }


### PR DESCRIPTION
ref: #10 

How about change short-hand options like these?
- `-M` as major
- `-m` as minor

```
$ vup --show
0.1.0
$ vup -m
0.2.0
$ vup -M
1.0.0
```
